### PR TITLE
Drops `openssl` pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,3 @@ Feedstock Maintainers
 
 * [@bollwyvl](https://github.com/bollwyvl/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -205,3 +205,6 @@ Feedstock Maintainers
 
 * [@bollwyvl](https://github.com/bollwyvl/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,5 @@ MACOSX_SDK_VERSION:        # [osx and x86_64]
 - '10.14'                  # [osx and x86_64]
 go_compiler:  # [win]
 - go-nocgo  # [win]
-openssl:
-- "1.1.1"
 c_compiler_version:
 - "10"  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 2ece3a0ddb3c9513f62933a48e2556b6a07c6aa3d6e63750ff1c01710608c1b4
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #9.


Here's a checklist to do before merging.
- [x] Bump the build number if needed.

Fixes https://github.com/conda-forge/kubo-feedstock/issues/9